### PR TITLE
T13932

### DIFF
--- a/debian/ndnsec-tools.postinst
+++ b/debian/ndnsec-tools.postinst
@@ -1,18 +1,20 @@
 #!/bin/sh
 set -e
 
-if ! ndnsec-get-default >/dev/null
-then # generate keys for this machine
-  ndnsec-keygen /localhost/operator | ndnsec-install-cert -
-fi
+if [ "$1" = configure ]; then
+  if ! ndnsec-get-default >/dev/null
+  then # generate keys for this machine
+    ndnsec-keygen /localhost/operator | ndnsec-install-cert -
+  fi
 
-# support EOS
-if [ -f /etc/lsb-release ]; then
-  . /etc/lsb-release
-  if [ "x${DISTRIB_ID}" = "xEndless" ]; then
-    if [ ! -e /usr/share/ndn/etc ]; then
-      mkdir -p /usr/share/ndn
-      mv /etc/ndn /usr/share/ndn/etc && ln -sf /usr/share/ndn/etc /etc/ndn
+  # support EOS
+  if [ -f /etc/lsb-release ]; then
+    . /etc/lsb-release
+    if [ "x${DISTRIB_ID}" = "xEndless" ]; then
+      if [ ! -e /usr/share/ndn/etc ]; then
+        mkdir -p /usr/share/ndn
+        mv /etc/ndn /usr/share/ndn/etc && ln -sf /usr/share/ndn/etc /etc/ndn
+      fi
     fi
   fi
 fi

--- a/debian/ndnsec-tools.postinst
+++ b/debian/ndnsec-tools.postinst
@@ -11,9 +11,9 @@ if [ "$1" = configure ]; then
       --group \
       ndn-user
 
-  if ! ndnsec-get-default >/dev/null
+  if ! su -s /bin/sh ndn-user -c ndnsec-get-default >/dev/null
   then # generate keys for this machine
-    ndnsec-keygen /localhost/operator | ndnsec-install-cert -
+    su -s /bin/sh ndn-user -c 'ndnsec-keygen /localhost/operator | ndnsec-install-cert -'
   fi
 
   # support EOS

--- a/debian/ndnsec-tools.postinst
+++ b/debian/ndnsec-tools.postinst
@@ -2,6 +2,15 @@
 set -e
 
 if [ "$1" = configure ]; then
+  # Add a user for all NDN related files and processes
+  adduser \
+      --system \
+      --quiet \
+      --home /var/lib/ndn \
+      --disabled-password \
+      --group \
+      ndn-user
+
   if ! ndnsec-get-default >/dev/null
   then # generate keys for this machine
     ndnsec-keygen /localhost/operator | ndnsec-install-cert -


### PR DESCRIPTION
A few commits to fix the `.postinst` script for ndn-cxx so that it:
 * creates an `ndn` user with `HOME=/var/lib/ndn`
 * creates the default keys in that directory, with the correct permissions
 * doesn’t do anything if not run as `postinst configure`